### PR TITLE
Set parse to False

### DIFF
--- a/src/integrations.py
+++ b/src/integrations.py
@@ -136,7 +136,7 @@ class KratosRegistrationWebhookIntegration:
                 emit_analytics_event=False,
                 response=ResponseConfig(
                     ignore=False,
-                    parse=True,
+                    parse=False,
                 ),
                 auth=AuthConfig(
                     config=_AuthConfig(


### PR DESCRIPTION
Set parse to `False` as we don't want kratos to parse the success response (it is empty)